### PR TITLE
chore: Fix auto test script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ project(dtkdevice
     VERSION ${VERSION}
 )
 
-
+# enable tests in advance to gather them
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    enable_testing()
+endif()
 add_subdirectory(dtklsdevice)
 add_subdirectory(dtkinputdevices)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo apt build-dep .
     Notice, under debug config, we can run
 
     ```bash
-    ./test-recoverage.sh
+    ./test-coverage.sh
     ```
 
     to acquire test coverage info.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -52,7 +52,7 @@ sudo apt build-dep .
     该配置下，会编译单元测试，用户可以运行
 
     ```bash
-    ./test-recoverage.sh
+    ./test-coverage.sh
     ```
 
     获取单元测试报告

--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 cmake -B build -DCMAKE_BUILD_TYPE=Debug
-cmake --build build --target ut-dtkinputdevices -- -j $(nproc)
+cmake --build build -- -j $(nproc)
 ctest --test-dir build -VV
 
 lcov -d build/ -c -o build/coverage_all.info


### PR DESCRIPTION
Fix auto test script, now we can use test-coverage.sh to run all unit tests and then generate html reports.

Log: Fix auto test script.