### PR TITLE
chore: exclude 3rdparty files from test coverage

### DIFF
--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -9,5 +9,5 @@ cmake --build build --target ut-dtkdevice -- -j $(nproc)
 ctest --test-dir build/tests -VV
 
 lcov -d build/tests -c -o build/coverage_all.info
-lcov --remove build/coverage_all.info "*/tests/*" "*/usr/include*" "*/moc*.cpp" --output-file build/coverage.info
+lcov --remove build/coverage_all.info "*/tests/*" "*/usr/include*" "*/moc*.cpp" "*/3rdparty/*" --output-file build/coverage.info
 genhtml -o build/coverage_html build/coverage.info


### PR DESCRIPTION
Exclude 3rdparty files when calculating test coverage.

Log: exclude 3rdparty files